### PR TITLE
Azure adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
         "league/flysystem-cached-adapter": "~1.0",
         "league/flysystem-sftp": "~1.0",
         "league/flysystem-ziparchive": "~1.0",
-	"league/flysystem-azure": "~1.0"
-
+        "league/flysystem-azure": "~1.0"
     },
     "autoload": {
         "psr-4": {
@@ -46,8 +45,7 @@
         "branch-alias": {
             "dev-master": "1.0.x-dev"
         }
-    }
-    ,
+    },
     "repositories": [
       {
         "type": "pear",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,9 @@
         "league/flysystem-dropbox": "~1.0",
         "league/flysystem-cached-adapter": "~1.0",
         "league/flysystem-sftp": "~1.0",
-        "league/flysystem-ziparchive": "~1.0"
+        "league/flysystem-ziparchive": "~1.0",
+	"league/flysystem-azure": "~1.0"
+
     },
     "autoload": {
         "psr-4": {
@@ -45,4 +47,11 @@
             "dev-master": "1.0.x-dev"
         }
     }
+    ,
+    "repositories": [
+      {
+        "type": "pear",
+        "url": "http://pear.php.net"
+      }
+    ]
 }

--- a/config/bsb_flysystem.global.php.dist
+++ b/config/bsb_flysystem.global.php.dist
@@ -69,7 +69,7 @@ return [
                     'password' => 'test'
                 ],
             ],
-            'sessions' => [
+            'azure_default' => [
                 'type' => 'azure',
                 'options' => [
                     'container' => 'your-container',

--- a/config/bsb_flysystem.global.php.dist
+++ b/config/bsb_flysystem.global.php.dist
@@ -69,6 +69,14 @@ return [
                     'password' => 'test'
                 ],
             ],
+            'sessions' => [
+                'type' => 'azure',
+                'options' => [
+                    'container' => 'your-container',
+                    'account-name' => 'xxxxx',
+                    'account-key' => 'xxxxx'
+                ],
+            ]
         ],
         'filesystems' => [
             'files' => [

--- a/src/Adapter/Factory/AzureAdapterFactory.php
+++ b/src/Adapter/Factory/AzureAdapterFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace BsbFlysystem\Adapter\Factory;
+
+use WindowsAzure\Common\ServicesBuilder;
+use League\Flysystem\Azure\AzureAdapter as Adapter;
+use UnexpectedValueException;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class AzureAdapterFactory extends AbstractAdapterFactory implements FactoryInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function doCreateService(ServiceLocatorInterface $serviceLocator)
+    {
+        $endpoint = sprintf('DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s', $this->options['account-name'], $this->options['account-key']);
+        $blobRestProxy = ServicesBuilder::getInstance()->createBlobService($endpoint);
+        $adapter = new Adapter($blobRestProxy, $this->options['container']);
+
+        return $adapter;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function validateConfig()
+    {
+        if (!isset($this->options['account-name'])) {
+            throw new UnexpectedValueException("Missing 'account-name' as option");
+        }
+        if (!isset($this->options['account-key'])) {
+            throw new UnexpectedValueException("Missing 'account-key' as option");
+        }
+        if (!isset($this->options['container'])) {
+            throw new UnexpectedValueException("Missing 'container' as option");
+        }
+    }
+}

--- a/src/Adapter/Factory/AzureAdapterFactory.php
+++ b/src/Adapter/Factory/AzureAdapterFactory.php
@@ -10,12 +10,17 @@ use Zend\ServiceManager\ServiceLocatorInterface;
 
 class AzureAdapterFactory extends AbstractAdapterFactory implements FactoryInterface
 {
+
     /**
      * @inheritdoc
      */
     public function doCreateService(ServiceLocatorInterface $serviceLocator)
     {
-        $endpoint = sprintf('DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s', $this->options['account-name'], $this->options['account-key']);
+        $endpoint = sprintf(
+            'DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s',
+            $this->options['account-name'],
+            $this->options['account-key']
+        );
         $blobRestProxy = ServicesBuilder::getInstance()->createBlobService($endpoint);
         $adapter = new Adapter($blobRestProxy, $this->options['container']);
 

--- a/src/Adapter/Factory/AzureAdapterFactory.php
+++ b/src/Adapter/Factory/AzureAdapterFactory.php
@@ -2,6 +2,7 @@
 
 namespace BsbFlysystem\Adapter\Factory;
 
+use BsbFlysystem\Exception\RequirementsException;
 use WindowsAzure\Common\ServicesBuilder;
 use League\Flysystem\Azure\AzureAdapter as Adapter;
 use UnexpectedValueException;
@@ -16,6 +17,12 @@ class AzureAdapterFactory extends AbstractAdapterFactory implements FactoryInter
      */
     public function doCreateService(ServiceLocatorInterface $serviceLocator)
     {
+        if (!class_exists('League\Flysystem\Azure\AzureAdapter')) {
+            throw new RequirementsException(
+                ['league/flysystem-azure'],
+                'Azure'
+            );
+        }
         $endpoint = sprintf(
             'DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s',
             $this->options['account-name'],

--- a/src/Service/Factory/AdapterManagerFactory.php
+++ b/src/Service/Factory/AdapterManagerFactory.php
@@ -17,6 +17,7 @@ class AdapterManagerFactory implements FactoryInterface
     protected $adapterMap = [
         'factories' => [
             'awss3'      => 'BsbFlysystem\Adapter\Factory\AwsS3AdapterFactory',
+            'azure'      => 'BsbFlysystem\Adapter\Factory\AzureAdapterFactory',
             'copy'       => 'BsbFlysystem\Adapter\Factory\CopyAdapterFactory',
             'dropbox'    => 'BsbFlysystem\Adapter\Factory\DropboxAdapterFactory',
             'ftp'        => 'BsbFlysystem\Adapter\Factory\FtpAdapterFactory',

--- a/test/Adapter/Factory/AzureAdapterFactoryTest.php
+++ b/test/Adapter/Factory/AzureAdapterFactoryTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace BsbFlysystemTest\Adapter\Factory;
+
+use BsbFlysystem\Adapter\Factory\AzureAdapterFactory;
+use BsbFlysystemTest\Bootstrap;
+use BsbFlysystemTest\Framework\TestCase;
+
+class AzureAdapterFactoryTest extends TestCase
+{
+    /**
+     * @var \ReflectionProperty
+     */
+    protected $property;
+
+    /**
+     * @var \ReflectionMethod
+     */
+    protected $method;
+
+    public function setup()
+    {
+        $class = new \ReflectionClass('BsbFlysystem\Adapter\Factory\AzureAdapterFactory');
+        $this->property = $class->getProperty('options');
+        $this->property->setAccessible(true);
+
+        $this->method = $class->getMethod('validateConfig');
+        $this->method->setAccessible(true);
+    }
+
+    public function testCreateService()
+    {
+        $sm = Bootstrap::getServiceManager();
+        $manager = $sm->get('BsbFlysystemAdapterManager');
+
+        $factory = new AzureAdapterFactory(
+            [
+                'account-name' => 'foo',
+                'account-key' => 'bar',
+                'container' => 'container',
+            ]
+        );
+
+        $adapter = $factory->createService($manager, 'azuredefault', 'azure_default');
+
+        $this->assertInstanceOf('League\Flysystem\Azure\AzureAdapter', $adapter);
+    }
+
+    /**
+     * @dataProvider validateConfigProvider
+     */
+    public function testValidateConfig(
+        $options,
+        $expectedOptions = false,
+        $expectedException = false,
+        $expectedExceptionMessage = false
+    ) {
+        $factory = new AzureAdapterFactory($options);
+
+        if ($expectedException) {
+            $this->setExpectedException($expectedException, $expectedExceptionMessage);
+        }
+
+        $this->method->invokeArgs($factory, []);
+
+        if (is_array($expectedOptions)) {
+            $this->assertEquals($expectedOptions, $this->property->getValue($factory));
+        }
+    }
+
+    public function validateConfigProvider()
+    {
+        return [
+            [
+                [],
+                [],
+                'UnexpectedValueException',
+                "Missing 'account-name' as option"
+            ],
+            [
+                ['account-name' => 'foo'],
+                [],
+                'UnexpectedValueException',
+                "Missing 'account-key' as option"
+            ],
+            [
+                [
+                    'account-name' => 'foo',
+                    'account-key' => 'bar',
+                ],
+                [],
+                'UnexpectedValueException',
+                "Missing 'container' as option"
+            ],
+            [
+                [
+                    'account-name' => 'foo',
+                    'account-key' => 'bar',
+                    'container' => 'container',
+                ],
+                [
+                    'account-name' => 'foo',
+                    'account-key' => 'bar',
+                    'container' => 'container',
+                ]
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Hey there!

For a project I am working with, we needed a way to store our files on Azure, so I created an Azure adapter for BsbFlysystem. Now I am wondering can I send in a pull request for it to be available by default?

The main problem I see is that the Azure backend requires the WindowsAzure SDK, which in turn require another repository to be added to the composer.json file. 

Othen than that, I have created a PR, which is without tests for now, please take a look, and if the changes are ok, I will add the required tests, and you can pull it in. 

In any case, I have tested this for myself, and it works as expected.