### PR TITLE
Sftp: Allowing no password option if privateKey is set

### DIFF
--- a/src/Adapter/Factory/SftpAdapterFactory.php
+++ b/src/Adapter/Factory/SftpAdapterFactory.php
@@ -44,8 +44,8 @@ class SftpAdapterFactory extends AbstractAdapterFactory implements FactoryInterf
             throw new UnexpectedValueException("Missing 'username' as option");
         }
 
-        if (!isset($this->options['password'])) {
-            throw new UnexpectedValueException("Missing 'password' as option");
+        if (!isset($this->options['password']) && !isset($this->options['privateKey'])) {
+            throw new UnexpectedValueException("Missing either 'password' or 'privateKey' as option");
         }
     }
 }

--- a/test/Adapter/Factory/SftpAdapterFactoryTest.php
+++ b/test/Adapter/Factory/SftpAdapterFactoryTest.php
@@ -90,11 +90,15 @@ class SftpAdapterFactoryTest extends TestCase
                 ['host' => 'foo', 'port' => 'foo', 'username' => 'foo'],
                 false,
                 'UnexpectedValueException',
-                "Missing 'password' as option"
+                "Missing either 'password' or 'privateKey' as option"
             ],
             [
                 ['host' => 'foo', 'port' => 'foo', 'username' => 'foo', 'password' => 'foo'],
                 ['host' => 'foo', 'port' => 'foo', 'username' => 'foo', 'password' => 'foo'],
+            ],
+            [
+                ['host' => 'foo', 'port' => 'foo', 'username' => 'foo', 'privateKey' => 'foo'],
+                ['host' => 'foo', 'port' => 'foo', 'username' => 'foo', 'privateKey' => 'foo'],
             ],
         ];
     }


### PR DESCRIPTION
The password option for sftp is not required when you have a passwordless ssh key. By the way, thank for the nice works!