### PR TITLE
Added S3v3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ I have tried to provide factories (and tests) for each of the adapters that come
 
 - Azure
 - Aws3S
+- Aws3Sv3
 - Copy
 - Dropbox
 - Ftp

--- a/config/bsb_flysystem.global.php.dist
+++ b/config/bsb_flysystem.global.php.dist
@@ -61,6 +61,18 @@ return [
                     'bucket' => 'xxxxx'
                 ],
             ],
+            'awss3v3_default'     => [
+                'type'       => 'awss3v3',
+                'options'    => [
+                    'credentials' => [
+                        'key'    => 'your-app-id',
+                        'secret' => 'xxxxx',
+                    ],
+                    'region'  => 'us-east-1',
+                    'bucket'  => 'xxxxx',
+                    'version' => 'latest|version', // default: 'latest'
+                ],
+            ],
             'webdav_default'    => [
                 'type'    => 'webdav',
                 'options' => [

--- a/src/Adapter/Factory/AwsS3v3AdapterFactory.php
+++ b/src/Adapter/Factory/AwsS3v3AdapterFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace BsbFlysystem\Adapter\Factory;
+
+use Aws\S3\S3Client;
+use BsbFlysystem\Exception\RequirementsException;
+use League\Flysystem\AwsS3v3\AwsS3Adapter as Adapter;
+use UnexpectedValueException;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class AwsS3v3AdapterFactory extends AbstractAdapterFactory implements FactoryInterface
+{
+
+    /**
+     * @inheritdoc
+     */
+    public function doCreateService(ServiceLocatorInterface $serviceLocator)
+    {
+        if (!class_exists('League\Flysystem\AwsS3v3\AwsS3Adapter')) {
+            throw new RequirementsException(
+                ['league/flysystem-aws-s3-v3'],
+                'AwsS3v3'
+            );
+        }
+        $client = new S3Client([
+            'credentials' => [
+                'key'    => $this->options['credentials']['key'],
+                'secret' => $this->options['credentials']['secret'],
+            ],
+            'region' => $this->options['region'],
+            'version' => $this->options['version'],
+        ]);
+
+        $adapter = new Adapter($client, $this->options['bucket'], $this->options['prefix']);
+
+        return $adapter;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function validateConfig()
+    {
+        if (!isset($this->options['credentials']) || !is_array($this->options['credentials'])) {
+            throw new UnexpectedValueException("Missing 'credentials' as array");
+        }
+
+        if (!isset($this->options['credentials']['key'])) {
+            throw new UnexpectedValueException("Missing 'key' as option");
+        }
+
+        if (!isset($this->options['credentials']['secret'])) {
+            throw new UnexpectedValueException("Missing 'secret' as option");
+        }
+
+        if (!isset($this->options['region'])) {
+            throw new UnexpectedValueException("Missing 'region' as option");
+        }
+
+        if (!isset($this->options['bucket'])) {
+            throw new UnexpectedValueException("Missing 'bucket' as option");
+        }
+
+        if (!isset($this->options['version'])) {
+            $this->options['version'] = 'latest';
+        }
+
+        if (!isset($this->options['prefix'])) {
+            $this->options['prefix'] = '';
+        }
+    }
+}

--- a/src/Service/Factory/AdapterManagerFactory.php
+++ b/src/Service/Factory/AdapterManagerFactory.php
@@ -18,6 +18,7 @@ class AdapterManagerFactory implements FactoryInterface
     protected $adapterMap = [
         'factories' => [
             'awss3'      => 'BsbFlysystem\Adapter\Factory\AwsS3AdapterFactory',
+            'awss3v3'    => 'BsbFlysystem\Adapter\Factory\AwsS3v3AdapterFactory',
             'azure'      => 'BsbFlysystem\Adapter\Factory\AzureAdapterFactory',
             'copy'       => 'BsbFlysystem\Adapter\Factory\CopyAdapterFactory',
             'dropbox'    => 'BsbFlysystem\Adapter\Factory\DropboxAdapterFactory',


### PR DESCRIPTION
Unfortunately I can't add tests because league/flysystem-aws-s3-v2 requires "aws/aws-sdk-php": "~2.7" and  league/flysystem-aws-s3-v3 requires "aws/aws-sdk-php": "^3.0"

Unless you can suggest something.