### PR TITLE
change flysystem version to less strict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "league/flysystem": "~1.0.0",
+        "league/flysystem": "~1.0",
         "zendframework/zend-servicemanager": "~2.2",
         "zendframework/zend-cache": "~2.2",
         "zendframework/zend-stdlib": "~2.2",


### PR DESCRIPTION
I think it's save because of http://thephpleague.com/#quality  rule number 6.
> Use Semantic Versioning to manage version numbers.