### PR TITLE
UploadRename filter allow only uploaded files for security reasons

### DIFF
--- a/src/Filter/File/RenameUpload.php
+++ b/src/Filter/File/RenameUpload.php
@@ -77,6 +77,12 @@ class RenameUpload extends RenameUploadFilter
      */
     protected function moveUploadedFile($sourceFile, $targetFile)
     {
+        if (!is_uploaded_file($sourceFile)) {
+            throw new Exception\RuntimeException(
+                sprintf("File '%s' could not be uploaded. Filter can move only uploaded files.", $sourceFile),
+                0
+            );
+        }
         $stream = fopen($sourceFile, 'r+');
         $result = $this->getFilesystem()->putStream($targetFile, $stream);
         fclose($stream);

--- a/test/Assets/Functions.php
+++ b/test/Assets/Functions.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BsbFlysystem\Filter\File
+{
+    function is_uploaded_file($filepath) {
+        return realpath($filepath) == realpath(__DIR__ . '/test.txt');
+    }
+}

--- a/test/Filter/File/RenameUploadTest.php
+++ b/test/Filter/File/RenameUploadTest.php
@@ -5,6 +5,7 @@ namespace BsbFlysystemTest\Filter\File;
 use BsbFlysystem\Filter\File\RenameUpload;
 use BsbFlysystemTest\Framework\TestCase;
 use Prophecy\Argument;
+require_once __DIR__ . '/../../Assets/Functions.php';
 
 class RenameUploadTest extends TestCase
 {
@@ -70,6 +71,24 @@ class RenameUploadTest extends TestCase
 
         $this->setExpectedException('UnexpectedValueException');
         $filter->filter(__DIR__ . '/../../Assets/test.txt');
+    }
+
+    public function testWillThrowExceptionWhenFileIsNotPostUploaded()
+    {
+        $path = 'path/to/file.txt';
+        $this->filesystem->has($path)
+            ->willReturn(false);
+
+        $filter = new RenameUpload([
+            'target' => $path,
+            'filesystem' => $this->filesystem->reveal()
+        ]);
+
+        $this->setExpectedException(
+            'Zend\Filter\Exception\RuntimeException',
+            "File '".__DIR__ . '/../../Assets/Functions.php'."' could not be uploaded. Filter can move only uploaded files."
+        );
+        $filter->filter(__DIR__ . '/../../Assets/Functions.php');
     }
 
     public function testWillThrowExceptionWhenFileExists()


### PR DESCRIPTION
since I removed `move_uploaded_file()` with ensures that file is uploaded thought POST request I had to add additional check for security reasons.