### PR TITLE
Guzzle request options support for Aws S3

### DIFF
--- a/config/bsb_flysystem.local.php.dist
+++ b/config/bsb_flysystem.local.php.dist
@@ -58,7 +58,8 @@ return [
                 'options' => [
                     'key'    => 'your-app-id',
                     'secret' => 'xxxxx',
-                    'bucket' => 'xxxxx'
+                    'bucket' => 'xxxxx',
+                    'request.options' => [], // Guzzle request options; see http://guzzle3.readthedocs.org/http-client/client.html#request-options
                 ],
             ],
             'awss3v3_default'     => [
@@ -71,6 +72,7 @@ return [
                     'region'  => 'us-east-1',
                     'bucket'  => 'xxxxx',
                     'version' => 'latest|version', // default: 'latest'
+                    'request.options' => [], // Guzzle request options; see http://docs.guzzlephp.org/en/latest/request-options.html#proxy
                 ],
             ],
             'webdav_default'    => [

--- a/src/Adapter/Factory/AwsS3AdapterFactory.php
+++ b/src/Adapter/Factory/AwsS3AdapterFactory.php
@@ -28,6 +28,7 @@ class AwsS3AdapterFactory extends AbstractAdapterFactory implements FactoryInter
             'key'    => $this->options['key'],
             'secret' => $this->options['secret'],
             'region' => $this->options['region'],
+            'request.options' => $this->options['request.options'],
         ]);
 
         $adapter = new Adapter($client, $this->options['bucket'], $this->options['prefix']);
@@ -58,6 +59,10 @@ class AwsS3AdapterFactory extends AbstractAdapterFactory implements FactoryInter
 
         if (!isset($this->options['prefix'])) {
             $this->options['prefix'] = null;
+        }
+
+        if (!isset($this->options['request.options'])) {
+            $this->options['request.options'] = [];
         }
     }
 }

--- a/src/Adapter/Factory/AwsS3v3AdapterFactory.php
+++ b/src/Adapter/Factory/AwsS3v3AdapterFactory.php
@@ -30,6 +30,7 @@ class AwsS3v3AdapterFactory extends AbstractAdapterFactory implements FactoryInt
             ],
             'region' => $this->options['region'],
             'version' => $this->options['version'],
+            'request.options' => $this->options['request.options'],
         ]);
 
         $adapter = new Adapter($client, $this->options['bucket'], $this->options['prefix']);
@@ -68,6 +69,10 @@ class AwsS3v3AdapterFactory extends AbstractAdapterFactory implements FactoryInt
 
         if (!isset($this->options['prefix'])) {
             $this->options['prefix'] = '';
+        }
+
+        if (!isset($this->options['request.options'])) {
+            $this->options['request.options'] = [];
         }
     }
 }

--- a/test/Adapter/Factory/AwsS3AdapterFactoryTest.php
+++ b/test/Adapter/Factory/AwsS3AdapterFactoryTest.php
@@ -111,6 +111,7 @@ class AwsS3AdapterFactoryTest extends TestCase
                     'region' => 'ghi',
                     'bucket' => 'jkl',
                     'prefix' => null,
+                    'request.options' => []
                 ]
             ],
         ];


### PR DESCRIPTION
Guzzle HTTP client supports `request.options` but none of adapter factories are utilizing it.

This option is very useful when there is a need to communicate with e.g. S3 service using proxy. See more about possible `request.options` values in http://guzzle3.readthedocs.org/http-client/client.html#request-options and http://docs.guzzlephp.org/en/latest/request-options.html.