### PR TITLE
Pass path and url parameters to Filesystem

### DIFF
--- a/config/bsb_flysystem.local.php.dist
+++ b/config/bsb_flysystem.local.php.dist
@@ -195,8 +195,8 @@ return [
                 'adapter' => 'local_default',
                 'adapter_options' => null,
                 'options' => [
-                    'pathNormalizer' => null, // returns PathNormalizer::class
-                    'publicUrlGenerator' => null, // returns \League\Flysystem\UrlGeneration\PublicUrlGeneratorInterface::class
+                    'pathNormalizer' => null, // returns \League\Flysystem\PathNormalizer::class
+                    'publicUrlGenerator' => null, // returns \League\Flysystem\UrlGeneration\PublicUrlGenerator::class
                     'temporaryUrlGenerator' => null, // returns \League\Flysystem\UrlGeneration\TemporaryUrlGenerator::class
                 ],
             ],

--- a/src/Adapter/Factory/AbstractAdapterFactory.php
+++ b/src/Adapter/Factory/AbstractAdapterFactory.php
@@ -107,12 +107,12 @@ abstract class AbstractAdapterFactory
     /**
      * Merges the options given from the ServiceLocator Config object with the create options of the class.
      */
-    protected function mergeMvcConfig(ContainerInterface $container, string $requestedName = null): void
+    protected function mergeMvcConfig(ContainerInterface $container, ?string $requestedName = null): void
     {
         $config = $container->has('config') ? $container->get('config') : [];
 
-        if (! isset($config['bsb_flysystem']['adapters'][$requestedName]['options']) ||
-            ! \is_array(($config['bsb_flysystem']['adapters'][$requestedName]['options']))
+        if (! isset($config['bsb_flysystem']['adapters'][$requestedName]['options'])
+            || ! \is_array(($config['bsb_flysystem']['adapters'][$requestedName]['options']))
         ) {
             return;
         }

--- a/src/Exception/RequirementsException.php
+++ b/src/Exception/RequirementsException.php
@@ -21,7 +21,7 @@ namespace BsbFlysystem\Exception;
 
 class RequirementsException extends RuntimeException
 {
-    public function __construct(array $requirements, string $for, int $code = 0, \Exception $previous = null)
+    public function __construct(array $requirements, string $for, int $code = 0, ?\Exception $previous = null)
     {
         $requirements = array_map(function ($r) {
             return sprintf("'%s'", trim($r));

--- a/src/Filesystem/Factory/FilesystemFactory.php
+++ b/src/Filesystem/Factory/FilesystemFactory.php
@@ -73,6 +73,21 @@ class FilesystemFactory
 
         $options = $configForRequestedFS['options'] ?? [];
 
-        return new Filesystem($adapter, $options);
+        $pathNormalizer = $options['pathNormalizer'] ?? null;
+        if (null !== $pathNormalizer) {
+            $pathNormalizer = $container->get($pathNormalizer);
+        }
+
+        $publicUrlGenerator = $options['publicUrlGenerator'] ?? null;
+        if (null !== $publicUrlGenerator) {
+            $publicUrlGenerator = $container->get($publicUrlGenerator);
+        }
+
+        $temporaryUrlGenerator = $options['temporaryUrlGenerator'] ?? null;
+        if (null !== $temporaryUrlGenerator) {
+            $temporaryUrlGenerator = $container->get($temporaryUrlGenerator);
+        }
+
+        return new Filesystem($adapter, $options, $pathNormalizer, $publicUrlGenerator, $temporaryUrlGenerator);
     }
 }

--- a/src/Service/Factory/FilesystemManagerFactory.php
+++ b/src/Service/Factory/FilesystemManagerFactory.php
@@ -25,7 +25,7 @@ use Psr\Container\ContainerInterface;
 
 class FilesystemManagerFactory
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): FilesystemManager
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): FilesystemManager
     {
         $filesystems = ($container->has('config') ? $container->get('config') : [])['bsb_flysystem']['filesystems'] ?? [];
 

--- a/test/Assets/bsb_flysystem.local.php
+++ b/test/Assets/bsb_flysystem.local.php
@@ -210,8 +210,8 @@ return [
                 'adapter' => 'local_default',
                 'adapter_options' => null,
                 'options' => [
-                    'pathNormalizer' => null, // returns PathNormalizer::class
-                    'publicUrlGenerator' => null, // returns \League\Flysystem\UrlGeneration\PublicUrlGeneratorInterface::class
+                    'pathNormalizer' => null, // returns \League\Flysystem\PathNormalizer::class
+                    'publicUrlGenerator' => null, // returns \League\Flysystem\UrlGeneration\PublicUrlGenerator::class
                     'temporaryUrlGenerator' => null, // returns \League\Flysystem\UrlGeneration\TemporaryUrlGenerator::class
                 ],
             ],


### PR DESCRIPTION
Currently filesystem options `pathNormalizer`, `publicUrlGenerator` and `temporaryUrlGenerator` do not do anything, because those are not being used while building `Filesystem`.